### PR TITLE
Fix error field name conversion

### DIFF
--- a/src/components/App.spec.js
+++ b/src/components/App.spec.js
@@ -18,7 +18,7 @@ describe('App Component', () => {
     const { getByTestId, getByPlaceholderText } = render(<App/>);
     fireEvent.change(getByPlaceholderText('Username'), { target: { value: inValidInputs.username } });
 
-    expect(getByTestId('username')).toHaveTextContent('The userName field must contain only alphabetic characters.');
+    expect(getByTestId('username')).toHaveTextContent('The user name field must contain only alphabetic characters.');
     expect(getByPlaceholderText('Username')).toHaveValue(inValidInputs.username);
   });
 
@@ -26,7 +26,7 @@ describe('App Component', () => {
     const { getByTestId, getByPlaceholderText } = render(<App/>);
     fireEvent.change(getByPlaceholderText('Username'), { target: { value: ' ' } });
 
-    expect(getByTestId('username')).toHaveTextContent('The userName field cannot be empty.');
+    expect(getByTestId('username')).toHaveTextContent('The user name field cannot be empty.');
     expect(getByPlaceholderText('Username')).toHaveValue(' ');
   });
 
@@ -57,12 +57,12 @@ describe('App Component', () => {
     const { getByTestId, getByPlaceholderText } = render(<App/>);
     fireEvent.change(getByPlaceholderText('Username'), { target: { value: inValidInputs.username } });
 
-    expect(getByTestId('username')).toHaveTextContent('The userName field must contain only alphabetic characters.');
+    expect(getByTestId('username')).toHaveTextContent('The user name field must contain only alphabetic characters.');
     expect(getByPlaceholderText('Username')).toHaveValue(inValidInputs.username);
 
     fireEvent.change(getByPlaceholderText('Username'), { target: { value: ' ' } });
 
-    expect(getByTestId('username')).toHaveTextContent('The userName field cannot be empty.');
+    expect(getByTestId('username')).toHaveTextContent('The user name field cannot be empty.');
     expect(getByPlaceholderText('Username')).toHaveValue(' ');
 
     fireEvent.change(getByPlaceholderText('Username'), { target: { value: validInputs.username } });
@@ -112,7 +112,7 @@ describe('App Component', () => {
         expect(element).toBe(undefined);
         expect(error).toBeTruthy();
         expect(error.message.includes('Unable to find an element by: [data-testid="table"]')).toBeTruthy();
-        expect(getByTestId('username')).toHaveTextContent('The userName field must contain only alphabetic characters.');
+        expect(getByTestId('username')).toHaveTextContent('The user name field must contain only alphabetic characters.');
       }
     });
   });

--- a/src/helpers/formatter.js
+++ b/src/helpers/formatter.js
@@ -1,0 +1,42 @@
+const pascalCase = (attribute) => {
+  let field = attribute;
+  field = `${field.slice(0, 1).toLowerCase()}${field.slice(1, field.lenght)}`;
+  return field;
+};
+
+const camelCase = (attribute) => {
+  let field = attribute;
+  const res = field.match(new RegExp('[A-Z]', 'g'));
+  let start = 0;
+
+  if (res) {
+    res.forEach((found) => {
+      const ind = field.indexOf(found, start);
+
+      field = `${field.slice(0, ind)} ${field.slice(ind, field.lenght)}`;
+      start = ind + 2;
+    });
+  }
+  return field.toLowerCase();
+};
+
+const snakeCase = (attribute) => {
+  let field = attribute;
+  const res = field.match(new RegExp('_', 'g'));
+  if (res) {
+    res.forEach(() => {
+      field = field.replace('_', ' ');
+    });
+  }
+
+  return field.toLowerCase();
+};
+
+const formatter = (attribute) => {
+  let field = pascalCase(attribute);
+  field = camelCase(field);
+  field = snakeCase(field);
+  return field;
+};
+
+export default formatter;

--- a/src/helpers/formatter.spec.js
+++ b/src/helpers/formatter.spec.js
@@ -1,0 +1,27 @@
+import formatter from './formatter';
+
+describe('App Component', () => {
+  it('should format PasCal name convention', () => {
+    const pascalCase = 'PasCal';
+    const formatted = formatter(pascalCase);
+
+    expect(formatted).not.toBe(pascalCase);
+    expect(formatted).toBe('pas cal');
+  });
+
+  it('should format camelCase name convention', () => {
+    const camelCase = 'camelCaseConvention';
+    const formatted = formatter(camelCase);
+
+    expect(formatted).not.toBe(camelCase);
+    expect(formatted).toBe('camel case convention');
+  });
+
+  it('should format sanke_case name convention', () => {
+    const snakeCase = 'snake_case_convention';
+    const formatted = formatter(snakeCase);
+
+    expect(formatted).not.toBe(snakeCase);
+    expect(formatted).toBe('snake case convention');
+  });
+});

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Validator from 'validatorjs';
+import formatter from '../helpers/formatter';
 
 const useForm = ({ callback, rules }) => {
   const prepareInitialState = () => {
@@ -10,6 +11,8 @@ const useForm = ({ callback, rules }) => {
 
   const [values, setValues] = useState(prepareInitialState());
   const [errors, setErrors] = useState({});
+
+  Validator.setAttributeFormatter(attribute => formatter(attribute));
 
   const validateOnSubmit = () => {
     let errorDoesNoExist = true;
@@ -56,7 +59,7 @@ const useForm = ({ callback, rules }) => {
     } = event;
 
     if (required && value.trim() === '') {
-      return errorHandler(name, value, `The ${name} field cannot be empty.`);
+      return errorHandler(name, value, `The ${formatter(name)} field cannot be empty.`);
     }
 
     const validation = new Validator(


### PR DESCRIPTION
#### What does this PR do?
- This PR fix error field name conversion

#### Description of task to be completed?
- create a formatter
- create PascalCase converter
- create camelCase converter
- create snake_case converter
- add formatter to validatorjs
- write test for formatter
- adjust other test files

#### How should this be manually tested?

  - $ git clone https://github.com/Eazybee/useFormBee.git 
  - $ npm install
  ##### Run Test
  - $ npm test
  ##### Run App
  - $ npm start

#### Any background context you want to provide?
- You would need npm  installed to run and test this application

#### Screenshots (if appropriate)
Notice: `userName`  changed to  `user name`
##### Before
<img width="1440" alt="Screenshot 2019-08-07 at 4 27 26 PM" src="https://user-images.githubusercontent.com/36575414/62636106-daaf4880-b930-11e9-8d20-806b7f4e2506.png">
##### After
<img width="1440" alt="Screenshot 2019-08-07 at 4 27 59 PM" src="https://user-images.githubusercontent.com/36575414/62636133-e6027400-b930-11e9-8d13-6846882ebe29.png">
